### PR TITLE
Add Awans Tesla Store

### DIFF
--- a/tesla_stores.py
+++ b/tesla_stores.py
@@ -23,6 +23,7 @@ class TeslaStore(int, Enum):
     AT_W = (9340, 'Wien')
 
     # Belgium
+    BE_AW = (32061, 'Awans')
     BE_BR = (14852, 'Brugge')
 
     # Czech Republic


### PR DESCRIPTION
Add Awans (https://www.tesla.com/fr_BE/findus/location/store/Liege-Awans) to Tesla Store list.