### PR TITLE
Add Toulon Delivery Hub to TeslaStore enumeration

### DIFF
--- a/tesla_stores.py
+++ b/tesla_stores.py
@@ -46,6 +46,7 @@ class TeslaStore(int, Enum):
     FR_ROU = (26278, 'Rouen Store')
     FR_BAY = (413853, 'Tesla Bayonne')
     FR_PAR = (407259, 'Tesla Paris St-Ouen')
+    FR_TLN = (4004152, 'Toulon Delivery Hub')
 
     # Germany
     DE_A = (3693, 'Augsburg Gersthofen')


### PR DESCRIPTION
feat: Add Toulon Delivery Hub to Tesla store locations

Added Tesla's Delivery Hub location in Toulon, France to the TeslaStore enum with ID 4004152.