### PR TITLE
Display checked on date

### DIFF
--- a/tesla_order_status.py
+++ b/tesla_order_status.py
@@ -8,6 +8,7 @@ import webbrowser
 import urllib.parse
 
 from tesla_stores import TeslaStore
+from datetime import datetime
 
 # Define constants
 CLIENT_ID = 'ownerapi'
@@ -204,6 +205,7 @@ if old_orders:
         save_orders_to_file(detailed_new_orders)
     else:
         print(color_text("No differences found.", '90'))
+        print(f"{color_text('Checked on', '90')} {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     
 else:
     # ask user if they want to save the new orders to a file for comparison next time


### PR DESCRIPTION
For a persons like me, who are refreshing the order status too often it may be useful to know if on this hour I already refresh it or not :D

I was wondering if I should use the same datetime format as for reservation and order booked date, but the simply `%H:%M:%S` is easier readable IMO.

<img width="1320" height="932" alt="image" src="https://github.com/user-attachments/assets/3be9d1b4-c454-42cc-abc4-f8507d4329d8" />
